### PR TITLE
Bump named-arrays to ~=2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,15 +13,15 @@
 import os
 import sys
 
-package_path = os.path.abspath('../')
+package_path = os.path.abspath("../")
 sys.path.insert(0, package_path)
-os.environ['PYTHONPATH'] = ';'.join((package_path, os.environ.get('PYTHONPATH', '')))
+os.environ["PYTHONPATH"] = ";".join((package_path, os.environ.get("PYTHONPATH", "")))
 
 # -- Project information -----------------------------------------------------
 
-project = 'msfc-ccd'
-copyright = '2024, Roy T. Smart'
-author = 'Roy T. Smart'
+project = "msfc-ccd"
+copyright = "2024, Roy T. Smart"
+author = "Roy T. Smart"
 
 # -- General configuration ---------------------------------------------------
 
@@ -29,16 +29,16 @@ author = 'Roy T. Smart'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.viewcode',
-    'sphinxcontrib.bibtex',
-    'jupyter_sphinx',
-    'nbsphinx',
-    'sphinx_codeautolink',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.viewcode",
+    "sphinxcontrib.bibtex",
+    "jupyter_sphinx",
+    "nbsphinx",
+    "sphinx_codeautolink",
 ]
 autosummary_generate = True  # Turn on sphinx.ext.autosummary
 autosummary_imported_members = True
@@ -46,28 +46,28 @@ autosummary_ignore_module_all = False
 
 autodoc_typehints = "description"
 
-graphviz_output_format = 'png'
-inheritance_graph_attrs = dict(rankdir='TB')
+graphviz_output_format = "png"
+inheritance_graph_attrs = dict(rankdir="TB")
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # This pattern also affects html_static_path and html_extra_path.
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_theme_options = {
     "icon_links": [
@@ -85,22 +85,22 @@ html_theme_options = {
     ],
     "analytics": {
         "google_analytics_id": "G-2STXRNV5RS",
-    }
+    },
 }
 
 # https://github.com/readthedocs/readthedocs.org/issues/2569
-master_doc = 'index'
+master_doc = "index"
 
-bibtex_bibfiles = ['refs.bib']
-bibtex_default_style = 'plain'
-bibtex_reference_style = 'author_year'
+bibtex_bibfiles = ["refs.bib"]
+bibtex_default_style = "plain"
+bibtex_reference_style = "author_year"
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'matplotlib': ('https://matplotlib.org/stable', None),
-    'astropy': ('https://docs.astropy.org/en/stable/', None),
-    'astroscrappy': ('https://astroscrappy.readthedocs.io/en/stable/', None),
-    'named_arrays': ('https://named-arrays.readthedocs.io/en/stable/', None),
-    'optika': ('https://optika.readthedocs.io/en/stable/', None),
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+    "astropy": ("https://docs.astropy.org/en/stable/", None),
+    "astroscrappy": ("https://astroscrappy.readthedocs.io/en/stable/", None),
+    "named_arrays": ("https://named-arrays.readthedocs.io/en/stable/", None),
+    "optika": ("https://optika.readthedocs.io/en/stable/", None),
 }

--- a/msfc_ccd/fits.py
+++ b/msfc_ccd/fits.py
@@ -4,7 +4,6 @@ import pathlib
 import named_arrays as na
 import msfc_ccd
 
-
 __all__ = [
     "open",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "astropy",
     "named-arrays~=2.0",
-    "optika~=1.0",
+    "optika~=2.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy",
-    "named-arrays~=1.0",
+    "named-arrays~=2.0",
     "optika~=1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Update the `named-arrays` dependency pin from `~=1.0` to `~=2.0` following the release of named-arrays 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)